### PR TITLE
Bump MNE dep

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - numpy
     - scipy
     - nibabel
-    - mne >=0.20
+    - mne >=0.19.1
     - pybv >=0.2.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
      - mne_bids = mne_bids.commands.run:main
@@ -25,7 +25,7 @@ requirements:
     - numpy
     - scipy
     - nibabel
-    - mne
+    - mne >=0.20
     - pybv >=0.2.0
 
 test:


### PR DESCRIPTION
Actually we now depend on MNE-Python 0.19.1 <strike>0.20 if I'm not mistaken. Need to update the MNE recipe too before merging this PR.

x-ref https://github.com/conda-forge/mne-feedstock/issues/25</strike>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
